### PR TITLE
Add Gnome 44 Support

### DIFF
--- a/notes@maestroschan.fr/metadata.json
+++ b/notes@maestroschan.fr/metadata.json
@@ -7,7 +7,8 @@
 		"40",
 		"41",
 		"42",
-		"43"
+		"43",
+		"44"
 	],
 	"url": "https://github.com/maoschanz/notes-extension-gnome",
 	"uuid": "notes@maestroschan.fr",


### PR DESCRIPTION
I have only added a version. I don't know if Gnome Shell 44 has breaking changes. But on my local machine extension is working now after adding version.