### PR TITLE
 Add Gnome Shell 45 and 46 compatibility.

### DIFF
--- a/notes@maestroschan.fr/dialog.js
+++ b/notes@maestroschan.fr/dialog.js
@@ -2,10 +2,13 @@
 // GPL v3
 // Copyright 2018-2021 Romain F. T.
 
-const { St, Clutter, GObject } = imports.gi;
-const ModalDialog = imports.ui.modalDialog;
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
 
-var CustomModalDialog = GObject.registerClass(
+import * as ModalDialog from 'resource:///org/gnome/shell/ui/modalDialog.js';
+
+export const CustomModalDialog = GObject.registerClass(
 class CustomModalDialog extends ModalDialog.ModalDialog {
 	_init(textTitle, bodyWidget, textOkButton, callback) {
 		super._init();
@@ -35,4 +38,3 @@ class CustomModalDialog extends ModalDialog.ModalDialog {
 		}]);
 	}
 });
-

--- a/notes@maestroschan.fr/extension.js
+++ b/notes@maestroschan.fr/extension.js
@@ -2,59 +2,51 @@
 // GPL v3
 // Copyright 2018-2021 Romain F. T.
 
-const { St, Shell, GLib, Gio, Meta } = imports.gi;
-const PanelMenu = imports.ui.panelMenu;
-const Panel = imports.ui.panel;
-const Main = imports.ui.main;
-const Mainloop = imports.mainloop;
+import St from 'gi://St';
+import Shell from 'gi://Shell';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+import Meta from 'gi://Meta';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
-const NoteBox = Me.imports.noteBox;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
-const Gettext = imports.gettext.domain('notes-extension');
-const _ = Gettext.gettext;
+import * as NoteBox from './noteBox.js';
 
 //------------------------------------------------------------------------------
 
-const PATH = GLib.build_pathv('/', [GLib.get_user_data_dir(), 'notes@maestroschan.fr']);
-// which is usually ~/.local/share/notes@maestroschan.fr
+export default class NotesExtension extends Extension {
+	enable() {
+		this._layerSetting = '';
+		this._settings = this.getSettings();
+		this._autoFocus = this._settings.get_boolean('auto-focus'); // XXX crado
+		this._dataPath = GLib.build_pathv('/', [GLib.get_user_data_dir(), 'notes@maestroschan.fr']);
+		// which is usually ~/.local/share/notes@maestroschan.fr
 
-var NOTES_MANAGER;
-var SETTINGS;
-var LAYER_SETTING;
-var AUTO_FOCUS;
-
-function init() {
-	ExtensionUtils.initTranslations();
-	try {
-		let a = Gio.file_new_for_path(PATH);
-		if (!a.query_exists(null)) {
-			a.make_directory(null);
+		try {
+			let a = Gio.file_new_for_path(this._dataPath);
+			if (!a.query_exists(null)) {
+				a.make_directory(null);
+			}
+		} catch (e) {
+			log(e.message);
 		}
-	} catch (e) {
-		log(e.message);
-	}
-	LAYER_SETTING = '';
-}
 
-function enable() {
-	SETTINGS = ExtensionUtils.getSettings();
-	AUTO_FOCUS = SETTINGS.get_boolean('auto-focus'); // XXX crado
-
-	NOTES_MANAGER = new NotesManager();
-}
-
-function disable() {
-	NOTES_MANAGER.destroy();
-
-	if (NOTES_MANAGER) {
-		NOTES_MANAGER = null;
+		this._notesManager = new NotesManager(this);
 	}
 
-	if (SETTINGS) {
-		SETTINGS = null;
+	disable() {
+		this._notesManager.destroy();
+
+		if (this._notesManager) {
+			this._notesManager = null;
+		}
+
+		if (this._settings) {
+			this._settings = null;
+		}
 	}
 }
 
@@ -69,7 +61,12 @@ function disable() {
  * new one.
  */
 class NotesManager {
-	constructor() {
+	constructor(extension) {
+		this._extension = extension;
+		this._settings = extension.getSettings();
+		this._layerSetting = extension._layerSetting;
+		this._dataPath = extension._dataPath;
+
 		// Initialisation of the button in the top panel
 		this.panel_button = new PanelMenu.Button(0.0, _("Show notes"), false);
 		let icon = new St.Icon({
@@ -99,11 +96,11 @@ class NotesManager {
 	}
 
 	_bindKeyboardShortcut () {
-		this._useKeyboardShortcut = SETTINGS.get_boolean('use-shortcut');
+		this._useKeyboardShortcut = this._settings.get_boolean('use-shortcut');
 		if (this._useKeyboardShortcut) {
 			Main.wm.addKeybinding(
 				'notes-kb-shortcut',
-				SETTINGS,
+				this._settings,
 				Meta.KeyBindingFlags.NONE,
 				Shell.ActionMode.ALL,
 				this._onButtonPressed.bind(this)
@@ -115,7 +112,7 @@ class NotesManager {
 		let i = 0;
 		let ended = false;
 		while(!ended) {
-			let file2 = GLib.build_filenamev([PATH, i.toString() + '_state']);
+			let file2 = GLib.build_filenamev([this._dataPath, i.toString() + '_state']);
 			if (GLib.file_test(file2, GLib.FileTest.EXISTS)) {
 				this.createNote('', 16);
 			} else {
@@ -133,7 +130,7 @@ class NotesManager {
 	createNote (colorString, fontSize) {
 		let nextId = this._allNotes.length;
 		try {
-			this._allNotes.push(new NoteBox.NoteBox(nextId, colorString, fontSize));
+			this._allNotes.push(new NoteBox.NoteBox(nextId, colorString, fontSize, this._extension));
 		} catch (e) {
 			Main.notify(_("Notes extension error: failed to load a note"));
 			log('failed to create note n°' + nextId.toString());
@@ -187,7 +184,7 @@ class NotesManager {
 
 	_hideNotes () {
 		this._onlyHideNotes();
-		this._timeout_id = Mainloop.timeout_add(10, () => {
+		this._timeout_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10, () => {
 			this._timeout_id = null;
 			// saving to the disk is slightly delayed to give the illusion that
 			// the extension doesn't freeze the system
@@ -206,7 +203,7 @@ class NotesManager {
 	}
 
 	_deleteNoteFiles (id) {
-		let filePathBeginning = PATH + '/' + id.toString();
+		let filePathBeginning = this._dataPath + '/' + id.toString();
 		let textfile = Gio.file_new_for_path(filePathBeginning + '_text');
 		let statefile = Gio.file_new_for_path(filePathBeginning + '_state');
 		textfile.delete(null); // may not do anything
@@ -220,7 +217,7 @@ class NotesManager {
 		// log('_onButtonPressed');
 
 		let preventReshowing = false;
-		if(LAYER_SETTING === 'cycle-layers') {
+		if(this._layerSetting === 'cycle-layers') {
 			this._allNotes.forEach(function (n) {
 				n.removeFromCorrectLayer();
 			});
@@ -261,27 +258,27 @@ class NotesManager {
 	_connectAllSignals () {
 		this._settingsSignals = {};
 
-		this._settingsSignals['layout'] = SETTINGS.connect(
+		this._settingsSignals['layout'] = this._settings.connect(
 			'changed::layout-position',
 			this._updateLayerSetting.bind(this)
 		);
-		this._settingsSignals['bring-back'] = SETTINGS.connect(
+		this._settingsSignals['bring-back'] = this._settings.connect(
 			'changed::ugly-hack',
 			this._bringToPrimaryMonitorOnly.bind(this)
 		);
-		this._settingsSignals['hide-icon'] = SETTINGS.connect(
+		this._settingsSignals['hide-icon'] = this._settings.connect(
 			'changed::hide-icon',
 			this._updateIconVisibility.bind(this)
 		);
-		this._settingsSignals['kb-shortcut-1'] = SETTINGS.connect(
+		this._settingsSignals['kb-shortcut-1'] = this._settings.connect(
 			'changed::use-shortcut',
 			this._updateShortcut.bind(this)
 		);
-		this._settingsSignals['kb-shortcut-2'] = SETTINGS.connect(
+		this._settingsSignals['kb-shortcut-2'] = this._settings.connect(
 			'changed::notes-kb-shortcut',
 			this._updateShortcut.bind(this)
 		);
-		this._settingsSignals['auto-focus'] = SETTINGS.connect(
+		this._settingsSignals['auto-focus'] = this._settings.connect(
 			'changed::auto-focus',
 			this._updateFocusSetting.bind(this)
 		);
@@ -303,7 +300,7 @@ class NotesManager {
 	}
 
 	_updateIconVisibility () {
-		let now_visible = !SETTINGS.get_boolean('hide-icon');
+		let now_visible = !this._settings.get_boolean('hide-icon');
 		this.panel_button.visible = now_visible;
 	}
 
@@ -323,8 +320,8 @@ class NotesManager {
 			n.removeFromCorrectLayer();
 		});
 
-		LAYER_SETTING = SETTINGS.get_string('layout-position');
-		this._layerId = (LAYER_SETTING == 'on-background')
+		this._layerSetting = this._settings.get_string('layout-position');
+		this._layerId = (this._layerSettings == 'on-background')
 			? 'on-background'
 			: 'above-all'
 		;
@@ -341,12 +338,12 @@ class NotesManager {
 	//--------------------------------------------------------------------------
 
 	destroy() {
-		SETTINGS.disconnect(this._settingsSignals['layout']);
-		SETTINGS.disconnect(this._settingsSignals['bring-back']);
-		SETTINGS.disconnect(this._settingsSignals['hide-icon']);
-		SETTINGS.disconnect(this._settingsSignals['kb-shortcut-1']);
-		SETTINGS.disconnect(this._settingsSignals['kb-shortcut-2']);
-		SETTINGS.disconnect(this._settingsSignals['auto-focus']);
+		this._settings.disconnect(this._settingsSignals['layout']);
+		this._settings.disconnect(this._settingsSignals['bring-back']);
+		this._settings.disconnect(this._settingsSignals['hide-icon']);
+		this._settings.disconnect(this._settingsSignals['kb-shortcut-1']);
+		this._settings.disconnect(this._settingsSignals['kb-shortcut-2']);
+		this._settings.disconnect(this._settingsSignals['auto-focus']);
 
 		this._allNotes.forEach(function (n) {
 			n.onlySave(false);
@@ -360,11 +357,10 @@ class NotesManager {
 		this.panel_button.destroy();
 
 		if (this._timeout_id) {
-			Mainloop.source_remove(this._timeout_id);
+			GLib.source_remove(this._timeout_id);
 			this._timeout_id = null;
 		}
 	}
 };
 
 //------------------------------------------------------------------------------
-

--- a/notes@maestroschan.fr/extension.js
+++ b/notes@maestroschan.fr/extension.js
@@ -321,7 +321,7 @@ class NotesManager {
 		});
 
 		this._layerSetting = this._settings.get_string('layout-position');
-		this._layerId = (this._layerSettings == 'on-background')
+		this._layerId = (this._layerSetting == 'on-background')
 			? 'on-background'
 			: 'above-all'
 		;

--- a/notes@maestroschan.fr/metadata.json
+++ b/notes@maestroschan.fr/metadata.json
@@ -4,11 +4,7 @@
 	"gettext-domain": "notes-extension",
 	"name": "Notes",
 	"shell-version": [
-		"40",
-		"41",
-		"42",
-		"43",
-		"44"
+		"45"
 	],
 	"url": "https://github.com/maoschanz/notes-extension-gnome",
 	"uuid": "notes@maestroschan.fr",

--- a/notes@maestroschan.fr/metadata.json
+++ b/notes@maestroschan.fr/metadata.json
@@ -4,7 +4,7 @@
 	"gettext-domain": "notes-extension",
 	"name": "Notes",
 	"shell-version": [
-		"45"
+		"45", "46"
 	],
 	"url": "https://github.com/maoschanz/notes-extension-gnome",
 	"uuid": "notes@maestroschan.fr",

--- a/notes@maestroschan.fr/noteBox.js
+++ b/notes@maestroschan.fr/noteBox.js
@@ -109,7 +109,13 @@ export const NoteBox = class NoteBox {
 		});
 
 		this._entryBox.add_child(this.noteEntry);
-		this._scrollView.add_actor(this._entryBox); // yes, actually add_actor
+
+		// For compatibility with GS 45 where add_child don't work
+		if (this._scrollView.add_actor === undefined) {
+			this._scrollView.add_child(this._entryBox);
+		} else {
+			this._scrollView.add_actor(this._entryBox);
+		}
 		this.actor.add_child(this._scrollView);
 
 		//----------------------------------------------------------------------
@@ -285,7 +291,7 @@ export const NoteBox = class NoteBox {
 //			Main.layoutManager.untrackChrome(this.actor);
 			Main.layoutManager.removeChrome(this.actor);
 		} else {
-			Main.layoutManager._backgroundGroup.remove_actor(this.actor);
+			Main.layoutManager._backgroundGroup.remove_child(this.actor);
 		}
 	}
 

--- a/notes@maestroschan.fr/prefs.js
+++ b/notes@maestroschan.fr/prefs.js
@@ -2,20 +2,15 @@
 // GPL v3
 // Copyright 2018-2021 Romain F. T.
 
-const{ GObject, Gtk, Gdk, GdkPixbuf, GLib } = imports.gi;
-const Mainloop = imports.mainloop;
+import GObject from 'gi://GObject';
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
+import GdkPixbuf from 'gi://GdkPixbuf';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
-const Gettext = imports.gettext.domain('notes-extension');
-const _ = Gettext.gettext;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-function init() {
-	ExtensionUtils.initTranslations();
-}
-
-let SETTINGS = ExtensionUtils.getSettings();
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 //------------------------------------------------------------------------------
 
@@ -23,9 +18,13 @@ const NotesSettingsWidget = new GObject.Class({
 	Name: 'NotesSettingsWidget',
 	GTypeName: 'NotesSettingsWidget',
 
-	_init () {
+	_init (extension) {
+		this._extension = extension;
+		this._settings = this._extension.getSettings();
+		this._path = this._extension.path;
+
 		let builder = new Gtk.Builder();
-		builder.add_from_file(Me.path+'/prefs.ui');
+		builder.add_from_file(this._path+'/prefs.ui');
 		this.prefs_stack = builder.get_object('prefs_stack');
 
 		this._buildSettingsPage(builder);
@@ -42,7 +41,7 @@ const NotesSettingsWidget = new GObject.Class({
 		let radioBtn1 = builder.get_object('radio1');
 		let radioBtn2 = builder.get_object('radio2');
 		let radioBtn3 = builder.get_object('radio3');
-		switch (SETTINGS.get_string('layout-position')) {
+		switch (this._settings.get_string('layout-position')) {
 			case 'above-all':
 				radioBtn1.set_active(true);
 			break;
@@ -61,18 +60,18 @@ const NotesSettingsWidget = new GObject.Class({
 		//----------------------------------------------------------------------
 
 		let focus_switch = builder.get_object('focus_switch');
-		focus_switch.set_state(SETTINGS.get_boolean('auto-focus'));
+		focus_switch.set_state(this._settings.get_boolean('auto-focus'));
 		focus_switch.connect('notify::active', (widget) => {
-			SETTINGS.set_boolean('auto-focus', widget.active);
+			this._settings.set_boolean('auto-focus', widget.active);
 		});
 
 		//----------------------------------------------------------------------
 
 		// The "hide icon" switch has to be build before the keybinding switch
 		this._hide_switch = builder.get_object('hide_switch');
-		this._hide_switch.set_state(SETTINGS.get_boolean('hide-icon'));
+		this._hide_switch.set_state(this._settings.get_boolean('hide-icon'));
 		this._hide_switch.connect('notify::active', (widget) => {
-			SETTINGS.set_boolean('hide-icon', widget.active);
+			this._settings.set_boolean('hide-icon', widget.active);
 		});
 
 		//----------------------------------------------------------------------
@@ -83,30 +82,30 @@ const NotesSettingsWidget = new GObject.Class({
 
 		// Text entry
 		let keybinding_entry = builder.get_object('keybinding_entry');
-		keybinding_entry.set_sensitive(SETTINGS.get_boolean('use-shortcut'));
+		keybinding_entry.set_sensitive(this._settings.get_boolean('use-shortcut'));
 		keybinding_entry.set_tooltip_text(default_kbs_label);
 
 		builder.get_object('default-kbs-help-1').set_label(default_kbs_label);
 		builder.get_object('default-kbs-help-2').set_label(RELOAD_TEXT);
 
-		if (SETTINGS.get_strv('notes-kb-shortcut') != '') {
-			keybinding_entry.text = SETTINGS.get_strv('notes-kb-shortcut')[0];
+		if (this._settings.get_strv('notes-kb-shortcut') != '') {
+			keybinding_entry.text = this._settings.get_strv('notes-kb-shortcut')[0];
 		}
 
 		// "Apply" button
 		let keybinding_button = builder.get_object('keybinding_button');
-		keybinding_button.set_sensitive(SETTINGS.get_boolean('use-shortcut'));
+		keybinding_button.set_sensitive(this._settings.get_boolean('use-shortcut'));
 
 		keybinding_button.connect('clicked', (widget) => {
-			SETTINGS.set_strv('notes-kb-shortcut', [keybinding_entry.text]);
+			this._settings.set_strv('notes-kb-shortcut', [keybinding_entry.text]);
 		});
 
 		// "Enable shortcut" switch
 		let keybinding_switch = builder.get_object('keybinding_switch');
-		keybinding_switch.set_state(SETTINGS.get_boolean('use-shortcut'));
+		keybinding_switch.set_state(this._settings.get_boolean('use-shortcut'));
 
 		keybinding_switch.connect('notify::active', (widget) => {
-			SETTINGS.set_boolean('use-shortcut', widget.active);
+			this._settings.set_boolean('use-shortcut', widget.active);
 			keybinding_entry.sensitive = widget.active;
 			keybinding_button.sensitive = widget.active;
 			this._hide_switch.sensitive = widget.active;
@@ -116,7 +115,7 @@ const NotesSettingsWidget = new GObject.Class({
 
 		// The default color of the very first note
 		let color_btn = builder.get_object('default_rgb_btn');
-		let colorArray = SETTINGS.get_strv('first-note-rgb');
+		let colorArray = this._settings.get_strv('first-note-rgb');
 		let rgba = new Gdk.RGBA();
 		rgba.red = parseFloat(colorArray[0]);
 		rgba.green = parseFloat(colorArray[1]);
@@ -126,7 +125,7 @@ const NotesSettingsWidget = new GObject.Class({
 
 		color_btn.connect('color-set', (widget) => {
 			rgba = widget.get_rgba();
-			SETTINGS.set_strv('first-note-rgb', [
+			this._settings.set_strv('first-note-rgb', [
 				rgba.red.toString(),
 				rgba.green.toString(),
 				rgba.blue.toString()
@@ -136,14 +135,14 @@ const NotesSettingsWidget = new GObject.Class({
 
 	_connectRadioBtn(strId, widget) {
 		widget.connect('toggled', (widget) => {
-			SETTINGS.set_string('layout-position', strId);
+			this._settings.set_string('layout-position', strId);
 		});
 	},
 
 	//--------------------------------------------------------------------------
 
 	_buildHelpPage(builder) {
-		let help_url = Me.metadata.url.toString();
+		let help_url = this._extension.metadata.url.toString();
 		help_url += "/blob/master/user-help/README.md";
 		builder.get_object('help_btn').set_uri(help_url);
 
@@ -155,7 +154,7 @@ const NotesSettingsWidget = new GObject.Class({
 
 		let reset_button = builder.get_object('reset_btn');
 		reset_button.connect('clicked', (widget) => {
-			SETTINGS.set_boolean('ugly-hack', !SETTINGS.get_boolean('ugly-hack'));
+			this._settings.set_boolean('ugly-hack', !this._settings.get_boolean('ugly-hack'));
 		});
 	},
 
@@ -163,11 +162,11 @@ const NotesSettingsWidget = new GObject.Class({
 
 	_buildAboutPage(builder) {
 		builder.get_object('about_icon').set_from_pixbuf(
-			GdkPixbuf.Pixbuf.new_from_file_at_size(Me.path +
+			GdkPixbuf.Pixbuf.new_from_file_at_size(this._path +
 		                             '/screenshots/about_picture.png', 163, 114)
 		);
 
-		let ext_version = _("Version %s").replace('%s', Me.metadata.version.toString());
+		let ext_version = _("Version %s").replace('%s', this._extension.metadata.version.toString());
 		builder.get_object('label_version').set_label(ext_version)
 
 		let translation_credits = builder.get_object('translation_credits').get_label();
@@ -176,7 +175,7 @@ const NotesSettingsWidget = new GObject.Class({
 			builder.get_object('translation_credits').set_label('');
 		}
 
-		let ext_report_url = Me.metadata.url.toString();
+		let ext_report_url = this._extension.metadata.url.toString();
 		builder.get_object('report_link_button').set_uri(ext_report_url);
 	}
 
@@ -184,12 +183,25 @@ const NotesSettingsWidget = new GObject.Class({
 
 //------------------------------------------------------------------------------
 
-// I guess this is like the "enable" in extension.js : something called each
-// time he user try to access the settings' window
-function buildPrefsWidget() {
-	let widget = new NotesSettingsWidget();
-	return widget.prefs_stack;
+export default class NotesPreferences extends ExtensionPreferences {
+	fillPreferencesWindow(window) {
+		const prefsPage = new Adw.PreferencesPage({
+				title: _("Notes Preferences"),
+				icon_name: "dialog-information-symbolic",
+		});
+
+		const prefsGroup = new Adw.PreferencesGroup({
+			title: "",
+			description: _("Configure the appearance of the extension"),
+		});
+
+		let widget = new NotesSettingsWidget(this);
+
+		prefsGroup.add(widget.prefs_stack);
+		prefsPage.add(prefsGroup);
+		window.add(prefsPage);
+
+		window.set_default_size(625, 650);
+	}
 }
-
 //------------------------------------------------------------------------------
-


### PR DESCRIPTION
Since ESM files contain import and export keywords, extension modules won't be compatible with older GNOME Shell versions. The old shell versions must be removed and only use 45 in shell-version in metadata.json!

[Port Extensions to GNOME Shell 45](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#shell-version)

This close #99 

![image](https://github.com/maoschanz/notes-extension-gnome/assets/73607126/110cab94-9ca6-4339-8bb5-f44d632fdd8e)

![image](https://github.com/maoschanz/notes-extension-gnome/assets/73607126/4419b41a-910c-4c97-bb2f-112387a37297)
